### PR TITLE
Update to modern conventions

### DIFF
--- a/whole-line-or-region.el
+++ b/whole-line-or-region.el
@@ -6,17 +6,15 @@
 ;; Author:          Joe Casadonte <emacs@northbound-train.com>
 ;; Maintainer:      Steve Purcell <steve@sanityinc.com>
 ;; Created:         July 1, 2001
-;; Modified:        August 11, 2017
+;; Modified:        August 13, 2017
 ;; Keywords:        convenience wp
 ;; Version:         1.3.1
 ;; Latest Version:  https://github.com/purcell/whole-line-or-region
 
-;; COPYRIGHT NOTICE
-
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either version 2, or (at your option)
-;; any later version.
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
 
 ;; This program is distributed in the hope that it will be useful,
 ;; but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -24,9 +22,7 @@
 ;; GNU General Public License for more details.
 
 ;; You should have received a copy of the GNU General Public License
-;; along with this program; see the file COPYING.  If not, write to the
-;; Free Software Foundation, Inc., 59 Temple Place - Suite 330,
-;; Boston, MA 02111-1307, USA.
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 ;;; Commentary:
 ;;
@@ -275,7 +271,7 @@ Optional ARG turns mode on iff ARG is a positive integer."
   :keymap 'whole-line-or-region-mode-map)
 
 ;;;###autoload
-(define-globalized-minor-mode global-whole-line-or-region-mode
+(define-globalized-minor-mode whole-line-or-region-global-mode
   whole-line-or-region-mode
   whole-line-or-region--turn-on
   :group 'whole-line-or-region)

--- a/whole-line-or-region.el
+++ b/whole-line-or-region.el
@@ -185,6 +185,17 @@
 (defvar whole-line-or-region-mode-map (make-sparse-keymap)
   "Minor mode map for `whole-line-or-region-mode'")
 
+;;;###autoload
+(defun whole-line-or-region-bind-keys ()
+  "Bind keys according to `whole-line-or-region-extensions-alist'."
+  (dolist (elem whole-line-or-region-extensions-alist)
+    (substitute-key-definition
+     (nth 0 elem)
+     (nth 1 elem)
+     whole-line-or-region-mode-map
+     (or (nth 2 elem) (current-global-map)))))
+
+
 ;;; **************************************************************************
 ;;; ***** customization
 ;;; **************************************************************************
@@ -242,18 +253,6 @@ If you set this through other means than customize be sure to run
   :set (lambda (symbol newval)
 		 (set symbol newval)
          (whole-line-or-region-bind-keys)))
-
-;;; Bind-keys function
-
-;;;###autoload
-(defun whole-line-or-region-bind-keys ()
-  "Bind keys according to `whole-line-or-region-extensions-alist'."
-  (dolist (elem whole-line-or-region-extensions-alist)
-    (substitute-key-definition
-     (nth 0 elem)
-     (nth 1 elem)
-     whole-line-or-region-mode-map
-     (or (nth 2 elem) (current-global-map)))))
 
 ;; ---------------------------------------------------------------------------
 


### PR DESCRIPTION
I really like this package but it’s usage of old conventions made it impossible to deactivate in specific buffers (it specifically interfered with pdf-view buffers).

I made a small effort to update it to modern minor-mode conventions with the definition of a buffer-local and a global minor mode which makes it possible to disable it for specific buffers.

In addition, the bindings are made through the minor-mode keymap, which then unfortunately may get shadowed by other minor modes (so defining overrides for functions defined in other minor-modes may or may not work, this depends on the order of `minor-mode-map-alist` which depends on loading order). But this still seemed cleaner than switching it on and off in the global keymap.

The second commit removes more of the legacy stuff in the file, but could possibly break people’s configuration as it removes the hooks currently defined.
(Instead of `whole-line-or-region-on-hook` and `whole-line-or-region-off-hook`, functions that check activation or deactivation by the value of `whole-line-or-region-mode` could be added to `whole-line-or-region-minor-mode-hook`. Instead of `lwhole-line-or-region-load-hook` a `(with-eval-after-load)` could be used.

I don’t know if many people on MELPA depends on the package and it’s old conventions so that this breakage would be disturbing, but for me the update makes much sense. I haven’t yet tested it extensively either but basically it seems to be working exactly as before.
