### PR TITLE
Rewrite internals

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+patreon: sanityinc

--- a/README.md
+++ b/README.md
@@ -1,0 +1,59 @@
+[![Melpa Status](http://melpa.org/packages/whole-line-or-region-badge.svg)](http://melpa.org/#/whole-line-or-region)
+[![Melpa Stable Status](http://stable.melpa.org/packages/whole-line-or-region-badge.svg)](http://stable.melpa.org/#/whole-line-or-region)
+[![Build Status](https://github.com/purcell/whole-line-or-region/workflows/CI/badge.svg)](https://github.com/purcell/whole-line-or-region/actions)
+<a href="https://www.patreon.com/sanityinc"><img alt="Support me" src="https://img.shields.io/badge/Support%20Me-%F0%9F%92%97-ff69b4.svg"></a>
+
+# In Emacs, operate on the current line if no region is active
+
+This minor mode allows functions to operate on the current line if
+they would normally operate on a region and region is currently
+undefined.
+
+The primary use for this is to kill (cut) the current line if no
+region is defined, and kill-region is invoked.  It basically saves you
+the effort of going to the begining of the line, selecting the text up
+to the end of the line, and killing.  Similarly, when yanking, it's
+smart enough to know that the string to be yanked was killed as a
+whole line, and it should be yanked as one, too.  So you don't need to
+position yourself at the start of the line before yanking.  If region
+*is* defined, though, all functions act as normal.
+
+This minor mode was originally written by Joe Casadonte in 2001, and
+was maintained for recent Emacsen by Steve Purcell for several
+years. In 2020 the internals were rewritten to use modern Emacs
+features such as `filter-buffer-substring-function` and
+`yank-handler`, and thereby behave more consistently.
+
+## Installation
+
+### Manual
+
+Ensure `whole-line-or-region.el` is in a directory on your load-path, and add
+the following to your `~/.emacs` or `~/.emacs.d/init.el`:
+
+```elisp
+(require 'whole-line-or-region)
+```
+
+### MELPA
+
+If you're an Emacs 24 user or you have a recent version of
+`package.el` you can install `whole-line-or-region` from the
+[MELPA](http://melpa.org) repository. The version of
+`whole-line-or-region` there will always be up-to-date.
+
+## About
+
+Author: Steve Purcell <steve at sanityinc dot com>
+
+Homepage: https://github.com/purcell/whole-line-or-region
+
+<hr>
+
+[💝 Support this project and my other Open Source work](https://www.patreon.com/sanityinc)
+
+[💼 LinkedIn profile](https://uk.linkedin.com/in/stevepurcell)
+
+[✍ sanityinc.com](https://www.sanityinc.com/)
+
+[🐦 @sanityinc](https://twitter.com/sanityinc)

--- a/README.md
+++ b/README.md
@@ -24,6 +24,23 @@ years. In 2020 the internals were rewritten to use modern Emacs
 features such as `filter-buffer-substring-function` and
 `yank-handler`, and thereby behave more consistently.
 
+# Usage
+
+Enabling `whole-line-or-region-global-mode` causes the common
+kill/copy commands to be remapped. When no region is active, if you
+type `C-w` then the current line will be copied. When yanked using
+`C-y`, it will be yanked _before_ the current line. If a region is
+active, e.g. if you have selected a word, the commands will behave as
+usual.
+
+Other commands are similarly overridden, e.g. `comment-dwim`: see
+`whole-line-or-region-local-mode-map` for more details.
+
+Functions are provided which allow you to easily wrap other commands
+so that they will also operate on the current line by default. The
+wrapped commands can then similarly be remapped in
+`whole-line-or-region-local-mode-map`.
+
 ## Installation
 
 ### Manual

--- a/whole-line-or-region-test.el
+++ b/whole-line-or-region-test.el
@@ -94,7 +94,8 @@ third"))
    (call-interactively 'whole-line-or-region-kill-region)
    "|"
    (yank)
-   "first|"))
+   "first
+|"))
 
 (ert-deftest wlr-yank-with-newline-in-empty-buffer ()
   (wlr-before-after
@@ -115,7 +116,8 @@ third"))
 |"
    (yank)
    "
-first|"))
+first
+|"))
 
 (ert-deftest wlr-kill-region-preserves-column ()
   (wlr-before-after

--- a/whole-line-or-region-test.el
+++ b/whole-line-or-region-test.el
@@ -86,6 +86,25 @@ fir|st
 second
 third"))
 
+(ert-deftest wlr-yank-excludes-properties ()
+  (wlr-before-after
+   "st|
+second
+third"
+   (let ((yank-excluded-properties (cons 'wlr-test-excluded yank-excluded-properties)))
+     (save-excursion
+       (goto-char (point-min))
+       (insert (propertize "fir" 'wlr-test-excluded t)))
+     (call-interactively 'whole-line-or-region-kill-ring-save)
+     (should (equal (current-kill 0) "first\n"))
+     ;; Should insert killed line before original line
+     (yank)
+     (should (not (get-text-property (- (point) 1) 'wlr-test-excluded))))
+   "first
+first|
+second
+third"))
+
 (ert-deftest wlr-kill-region ()
   (wlr-before-after
    "fir|st

--- a/whole-line-or-region-test.el
+++ b/whole-line-or-region-test.el
@@ -87,6 +87,17 @@ fir|st
 second
 third"))
 
+(ert-deftest wlr-copy-whole-line-bol ()
+  (wlr-before-after
+   "|first
+second"
+   (call-interactively 'whole-line-or-region-kill-ring-save)
+   (should (equal (current-kill 0) "first\n"))
+   (yank)
+   "first
+|first
+second"))
+
 (ert-deftest wlr-copy-whole-line-when-readonly ()
   (wlr-before-after
    "fir|st
@@ -164,6 +175,43 @@ third"
    "second
 first
 third|"))
+
+(ert-deftest wlr-consecutive-kill-region-combines-them ()
+  (wlr-before-after
+   "fir|st
+second
+third"
+   (call-interactively 'whole-line-or-region-kill-region)
+   (should (equal (current-kill 0) "first\n"))
+   "|second
+third"
+   (let ((last-command 'kill-region))
+     (call-interactively 'whole-line-or-region-kill-region))
+   (should (equal (current-kill 0) "first\nsecond\n"))
+   (forward-char 3)
+   "thi|rd"
+   (yank)
+   "first
+second
+thi|rd"))
+
+(ert-deftest wlr-consecutive-kill-region-combines-them-bol ()
+  (wlr-before-after
+   "fir|st
+second
+third"
+   (call-interactively 'whole-line-or-region-kill-region)
+   (should (equal (current-kill 0) "first\n"))
+   "|second
+third"
+   (let ((last-command 'kill-region))
+     (call-interactively 'whole-line-or-region-kill-region))
+   (should (equal (current-kill 0) "first\nsecond\n"))
+   "|third"
+   (yank)
+   "first
+second
+|third"))
 
 (ert-deftest wlr-copy-works-without-transient-mark-mode ()
   (let (transient-mark-mode)

--- a/whole-line-or-region-test.el
+++ b/whole-line-or-region-test.el
@@ -232,7 +232,8 @@ third"
    (yank)
    "first
 second
-thi|rd"))
+thi|rd"
+   (should (equal (point-min) (mark)))))
 
 (ert-deftest wlr-consecutive-kill-region-combines-them-bol ()
   (wlr-before-after

--- a/whole-line-or-region-test.el
+++ b/whole-line-or-region-test.el
@@ -97,6 +97,21 @@ third"
    (call-interactively 'whole-line-or-region-copy-region-as-kill)
    (should (equal (current-kill 0) "second\n"))))
 
+(ert-deftest wlr-honours-kill-read-only-ok ()
+  (wlr-before-after
+   "fir|st
+second
+third"
+   (read-only-mode 1)
+   (should-error (call-interactively 'whole-line-or-region-kill-region))
+   (let ((kill-read-only-ok t))
+     (call-interactively 'whole-line-or-region-kill-region)
+     (should (equal (current-kill 0) "first\n")))
+   "fir|st
+second
+third"))
+
+
 (ert-deftest wlr-yank-excludes-properties ()
   (wlr-before-after
    "st|

--- a/whole-line-or-region-test.el
+++ b/whole-line-or-region-test.el
@@ -164,22 +164,6 @@ third"
 first
 third|"))
 
-(ert-deftest wlr-kill-region ()
-  (wlr-before-after
-   "fir|st
-second
-third"
-   (call-interactively 'whole-line-or-region-kill-region)
-   (should (equal (current-kill 0) "first\n"))
-   "|second
-third"
-   (goto-char (point-max))
-   ;; Should insert killed line before original line
-   (yank)
-   "second
-first
-third|"))
-
 (ert-deftest wlr-copy-works-without-transient-mark-mode ()
   (let (transient-mark-mode)
     (wlr-before-after

--- a/whole-line-or-region-test.el
+++ b/whole-line-or-region-test.el
@@ -87,6 +87,13 @@ fir|st
 second
 third"))
 
+(ert-deftest wlr-kill-region-preserves-column ()
+  (wlr-before-after
+   "fir|st
+second"
+   (call-interactively 'whole-line-or-region-kill-region)
+   "sec|ond"))
+
 (ert-deftest wlr-copy-whole-line-bol ()
   (wlr-before-after
    "|first
@@ -167,7 +174,7 @@ second
 third"
    (call-interactively 'whole-line-or-region-kill-region)
    (should (equal (current-kill 0) "first\n"))
-   "|second
+   "sec|ond
 third"
    (goto-char (point-max))
    ;; Should insert killed line before original line
@@ -183,12 +190,11 @@ second
 third"
    (call-interactively 'whole-line-or-region-kill-region)
    (should (equal (current-kill 0) "first\n"))
-   "|second
+   "sec|ond
 third"
    (let ((last-command 'kill-region))
      (call-interactively 'whole-line-or-region-kill-region))
    (should (equal (current-kill 0) "first\nsecond\n"))
-   (forward-char 3)
    "thi|rd"
    (yank)
    "first
@@ -197,7 +203,7 @@ thi|rd"))
 
 (ert-deftest wlr-consecutive-kill-region-combines-them-bol ()
   (wlr-before-after
-   "fir|st
+   "|first
 second
 third"
    (call-interactively 'whole-line-or-region-kill-region)

--- a/whole-line-or-region-test.el
+++ b/whole-line-or-region-test.el
@@ -86,6 +86,17 @@ fir|st
 second
 third"))
 
+(ert-deftest wlr-copy-whole-line-when-readonly ()
+  (wlr-before-after
+   "fir|st
+second
+third"
+   (read-only-mode 1)
+   (call-interactively 'whole-line-or-region-kill-ring-save)
+   (should (equal (current-kill 0) "first\n"))   (forward-line 1)
+   (call-interactively 'whole-line-or-region-copy-region-as-kill)
+   (should (equal (current-kill 0) "second\n"))))
+
 (ert-deftest wlr-yank-excludes-properties ()
   (wlr-before-after
    "st|

--- a/whole-line-or-region-test.el
+++ b/whole-line-or-region-test.el
@@ -111,7 +111,6 @@ third"
 second
 third"))
 
-
 (ert-deftest wlr-yank-excludes-properties ()
   (wlr-before-after
    "st|
@@ -147,20 +146,32 @@ third"
 first
 third|"))
 
-(ert-deftest wlr-yank-with-mode-disabled ()
+(ert-deftest wlr-kill-region ()
   (wlr-before-after
    "fir|st
 second
 third"
-   (call-interactively 'whole-line-or-region-kill-ring-save)
+   (call-interactively 'whole-line-or-region-kill-region)
    (should (equal (current-kill 0) "first\n"))
-   (whole-line-or-region-local-mode -1)
-   ;; Should insert killed line at point, not on previous line
+   "|second
+third"
+   (goto-char (point-max))
+   ;; Should insert killed line before original line
    (yank)
-   "firfirst
-|st
+   "second
+first
+third|"))
+
+(ert-deftest wlr-copy-works-without-transient-mark-mode ()
+  (let (transient-mark-mode)
+    (wlr-before-after
+     "fir|st
 second
-third"))
+third"
+     (set-mark (point-min))
+     (should (not (region-active-p)))
+     (call-interactively 'whole-line-or-region-kill-ring-save)
+     (should (equal (current-kill 0) "fir")))))
 
 (ert-deftest wlr-copy-several-whole-lines ()
   (wlr-before-after

--- a/whole-line-or-region-test.el
+++ b/whole-line-or-region-test.el
@@ -88,6 +88,35 @@ fir|st
 second
 third"))
 
+(ert-deftest wlr-yank-in-empty-buffer ()
+  (wlr-before-after
+   "fir|st"
+   (call-interactively 'whole-line-or-region-kill-region)
+   "|"
+   (yank)
+   "first|"))
+
+(ert-deftest wlr-yank-with-newline-in-empty-buffer ()
+  (wlr-before-after
+   "fir|st\n"
+   (call-interactively 'whole-line-or-region-kill-region)
+   "|"
+   (yank)
+   "first
+|"))
+
+(ert-deftest wlr-yank-in-empty-buffer-with-newline ()
+  (wlr-before-after
+   "fir|st"
+   (call-interactively 'whole-line-or-region-kill-region)
+   "|"
+   (newline)
+   "
+|"
+   (yank)
+   "
+first|"))
+
 (ert-deftest wlr-kill-region-preserves-column ()
   (wlr-before-after
    "fir|st

--- a/whole-line-or-region-test.el
+++ b/whole-line-or-region-test.el
@@ -48,15 +48,16 @@ the expected buffer contents (like BEFORE), and will be replaced
 with a corresponding assertion on the buffer's current state."
   (pcase-let ((`(,initial-text . ,initial-offset) (wlr-picture-to-text-and-offset before)))
     `(with-temp-buffer
-       (insert ,initial-text)
-       (goto-char ,initial-offset)
-       (setq-local comment-start "#")
-       (whole-line-or-region-local-mode 1)
-       ,@(mapcar (lambda (step)
-                   (if (stringp step)
-                       `(should (equal ,step (wlr-make-picture)))
-                     step))
-                 steps))))
+       (let (kill-ring)
+         (insert ,initial-text)
+         (goto-char ,initial-offset)
+         (setq-local comment-start "#")
+         (whole-line-or-region-local-mode 1)
+         ,@(mapcar (lambda (step)
+                     (if (stringp step)
+                         `(should (equal ,step (wlr-make-picture)))
+                       step))
+                   steps)))))
 
 (ert-deftest wlr-copy-whole-line-region-active ()
   (wlr-before-after

--- a/whole-line-or-region-test.el
+++ b/whole-line-or-region-test.el
@@ -130,6 +130,24 @@ first|
 second
 third"))
 
+(ert-deftest wlr-yank-undo ()
+  (wlr-before-after
+   "first|
+second
+third"
+   (call-interactively 'whole-line-or-region-kill-ring-save)
+   (yank)
+   "first
+first|
+second
+third"
+   (let ((last-command 'yank)
+         (kill-ring '("blah")))
+     (yank-pop))
+   "firstblah|
+second
+third"))
+
 (ert-deftest wlr-kill-region ()
   (wlr-before-after
    "fir|st

--- a/whole-line-or-region-test.el
+++ b/whole-line-or-region-test.el
@@ -82,6 +82,7 @@ third"
    (should (equal (current-kill 0) "first\n"))
    ;; Should insert killed line before original line
    (yank)
+   (should (eq (point-min) (mark)))
    "first
 fir|st
 second
@@ -101,6 +102,7 @@ second"
    (call-interactively 'whole-line-or-region-kill-ring-save)
    (should (equal (current-kill 0) "first\n"))
    (yank)
+   (should (eq (point-min) (mark)))
    "first
 |first
 second"))

--- a/whole-line-or-region.el
+++ b/whole-line-or-region.el
@@ -135,7 +135,7 @@ When ENSURE-NEWLINE is non-nil, add a newline if there was none."
     (insert-before-markers string)
     (push-mark beg)
     (remove-yank-excluded-properties beg (point))
-    (when (and ensure-newline (not (eq (char-before) ?\n)))
+    (when (and ensure-newline (not (eq (char-before) ?\n)) (not (eobp)))
       (insert-before-markers "\n"))
     (setq end (point))
     (setq yank-undo-function

--- a/whole-line-or-region.el
+++ b/whole-line-or-region.el
@@ -123,18 +123,25 @@ STRING is the string being yanked."
            whole-line-or-region-local-mode)
       (save-excursion
         (move-beginning-of-line 1)
-        (whole-line-or-region-insert-clean string)
-        (unless (eq (char-before) ?\n)
-          (insert "\n")))
-    (whole-line-or-region-insert-clean string)))
+        (whole-line-or-region-insert-clean string t))
+    (whole-line-or-region-insert-clean string nil)))
 
-(defun whole-line-or-region-insert-clean (string)
+(defun whole-line-or-region-insert-clean (string &optional ensure-newline)
   "Insert STRING and remove `yank-excluded-properties'.
 This is needed because the yank handler may move point, and is
 therefore registered with the NOEXCLUDE flag: this causes `yank'
-to not remove the excluded properties itself."
-  (insert string)
-  (remove-yank-excluded-properties (point) (- (point) (length string))))
+to not remove the excluded properties itself
+
+When ENSURE-NEWLINE is non-nil, add a newline if there was none."
+  (let ((beg (point))
+        end)
+    (insert string)
+    (remove-yank-excluded-properties (point) (- (point) (length string)))
+    (when (and ensure-newline (not (eq (char-before) ?\n)))
+      (insert "\n"))
+    (setq end (point))
+    (setq yank-undo-function
+          (lambda (_beg _end) (delete-region beg end)))))
 
 
 ;;; Helpers for wrapping commands

--- a/whole-line-or-region.el
+++ b/whole-line-or-region.el
@@ -135,10 +135,10 @@ to not remove the excluded properties itself
 When ENSURE-NEWLINE is non-nil, add a newline if there was none."
   (let ((beg (point))
         end)
-    (insert string)
+    (insert-before-markers string)
     (remove-yank-excluded-properties beg (point))
     (when (and ensure-newline (not (eq (char-before) ?\n)))
-      (insert "\n"))
+      (insert-before-markers "\n"))
     (setq end (point))
     (setq yank-undo-function
           (lambda (_beg _end) (delete-region beg end)))))

--- a/whole-line-or-region.el
+++ b/whole-line-or-region.el
@@ -128,8 +128,9 @@ STRING is the string being yanked."
   (if (and (not (and delete-selection-mode mark-active))
            whole-line-or-region-local-mode)
       (whole-line-or-region-preserve-column
-       (forward-line 0)
-       (push-mark nil t)
+       (unless (bolp)
+         (forward-line 0)
+         (push-mark nil t))
        (whole-line-or-region-insert-clean string t))
     (whole-line-or-region-insert-clean string nil)))
 

--- a/whole-line-or-region.el
+++ b/whole-line-or-region.el
@@ -122,7 +122,7 @@ STRING is the string being yanked."
   (if (and (not (and delete-selection-mode mark-active))
            whole-line-or-region-local-mode)
       (save-excursion
-        (move-beginning-of-line 1)
+        (forward-line 0)
         (whole-line-or-region-insert-clean string t))
     (whole-line-or-region-insert-clean string nil)))
 

--- a/whole-line-or-region.el
+++ b/whole-line-or-region.el
@@ -167,8 +167,10 @@ The binding ensure killed strings have a yank handler attached."
             (filter-buffer-substring-function
              (lambda (&rest args)
                (let ((s (apply ,orig args)))
-                 (propertize s 'yank-handler
-                             (list 'whole-line-or-region-yank-handler nil t))))))
+                 (put-text-property 0 (length s) 'yank-handler
+                                    '(whole-line-or-region-yank-handler nil t)
+                                    s)
+                 s))))
        ,@body)))
 
 (defun whole-line-or-region-wrap-region-kill (f num-lines)

--- a/whole-line-or-region.el
+++ b/whole-line-or-region.el
@@ -123,10 +123,18 @@ STRING is the string being yanked."
            whole-line-or-region-local-mode)
       (save-excursion
         (move-beginning-of-line 1)
-        (insert string)
+        (whole-line-or-region-insert-clean string)
         (unless (eq (char-before) ?\n)
           (insert "\n")))
-    (insert string)))
+    (whole-line-or-region-insert-clean string)))
+
+(defun whole-line-or-region-insert-clean (string)
+  "Insert STRING and remove `yank-excluded-properties'.
+This is needed because the yank handler may move point, and is
+therefore registered with the NOEXCLUDE flag: this causes `yank'
+to not remove the excluded properties itself."
+  (insert string)
+  (remove-yank-excluded-properties (point) (- (point) (length string))))
 
 
 ;;; Helpers for wrapping commands

--- a/whole-line-or-region.el
+++ b/whole-line-or-region.el
@@ -139,6 +139,12 @@ to not remove the excluded properties itself."
 
 ;;; Helpers for wrapping commands
 
+(defun whole-line-or-region-use-region-p ()
+  "Return non-nil if we expect underlying commands to use the region."
+  (and mark-active
+       (or use-empty-active-region
+           (> (region-end) (region-beginning)))))
+
 (defmacro whole-line-or-region-filter-with-yank-handler (&rest body)
   "Execute BODY with `filter-buffer-substring-function' bound.
 The binding ensure killed strings have a yank handler attached."
@@ -160,7 +166,7 @@ If NUM-LINES is non-zero and the region is inactive, it denotes
 the number of lines to operate upon, where positive numbers
 indicate lines after point, and negative numbers represent lines
 preceding point."
-  (if (use-region-p)
+  (if (whole-line-or-region-use-region-p)
       (funcall f (region-beginning) (region-end) 'region)
     (whole-line-or-region-filter-with-yank-handler
      (funcall f
@@ -178,7 +184,7 @@ If NUM-LINES is non-zero and the region is inactive, it denotes
 the number of lines to operate upon, where positive numbers
 indicate lines after point, and negative numbers represent lines
 preceding point."
-  (if (use-region-p)
+  (if (whole-line-or-region-use-region-p)
       (apply f (region-beginning) (region-end) rest)
     (apply f
            (line-beginning-position 1)
@@ -197,7 +203,7 @@ If NUM-LINES is non-zero and the region is inactive, it denotes
 the number of lines to operate upon, where positive numbers
 indicate lines after point, and negative numbers represent lines
 preceding point."
-  (if (use-region-p)
+  (if (whole-line-or-region-use-region-p)
       (apply f rest)
     (save-excursion
       (set-mark (line-beginning-position 1))

--- a/whole-line-or-region.el
+++ b/whole-line-or-region.el
@@ -257,9 +257,6 @@ Optional ARG turns mode on iff ARG is a positive integer."
   whole-line-or-region--turn-on
   :group 'whole-line-or-region)
 
-;;;###autoload
-(define-obsolete-function-alias 'whole-line-or-region-mode 'whole-line-or-region-global-mode)
-
 (defun whole-line-or-region--turn-on ()
   (whole-line-or-region-local-mode +1))
 

--- a/whole-line-or-region.el
+++ b/whole-line-or-region.el
@@ -210,7 +210,7 @@ preceding point."
 ;;;###autoload
 (defun whole-line-or-region-copy-region-as-kill (prefix)
   "Call `copy-region-as-kill' on region or PREFIX whole lines."
-  (interactive "*p")
+  (interactive "p")
   (whole-line-or-region-wrap-region-kill 'copy-region-as-kill prefix))
 
 ;;;###autoload
@@ -222,7 +222,7 @@ preceding point."
 ;;;###autoload
 (defun whole-line-or-region-kill-ring-save (prefix)
   "Call `kill-ring-save' on region or PREFIX whole lines."
-  (interactive "*p")
+  (interactive "p")
   (whole-line-or-region-wrap-region-kill 'kill-ring-save prefix))
 
 ;;;###autoload

--- a/whole-line-or-region.el
+++ b/whole-line-or-region.el
@@ -216,7 +216,7 @@ preceding point."
 ;;;###autoload
 (defun whole-line-or-region-kill-region (prefix)
   "Call `kill-region' on region or PREFIX whole lines."
-  (interactive "*p")
+  (interactive "p")
   (whole-line-or-region-wrap-region-kill 'kill-region prefix))
 
 ;;;###autoload

--- a/whole-line-or-region.el
+++ b/whole-line-or-region.el
@@ -3,12 +3,14 @@
 ;; This file is not part of Emacs
 
 ;; Copyright (C) 2001 by Joseph L. Casadonte Jr.
+;; Copyright (C) 2011-2020 Steve Purcell
 ;; Author:          Joe Casadonte <emacs@northbound-train.com>
+;; Author:          Steve Purcell <steve@sanityinc.com>
 ;; Maintainer:      Steve Purcell <steve@sanityinc.com>
 ;; Created:         July 1, 2001
 ;; Keywords:        convenience wp
 ;; Package-Version: 0
-;; Package-Requires: ((emacs "24.1"))
+;; Package-Requires: ((emacs "24.1") (cl-lib "0.6"))
 ;; Homepage:  https://github.com/purcell/whole-line-or-region
 
 ;; This program is free software; you can redistribute it and/or modify
@@ -26,464 +28,232 @@
 
 ;;; Commentary:
 ;;
-;;  This minor mode allows functions to operate on the current line if
-;;  they would normally operate on a region and region is currently
-;;  undefined.
+;; This minor mode allows functions to operate on the current line if
+;; they would normally operate on a region and region is currently
+;; undefined.
 ;;
-;;  The primary use for this is to kill (cut) the current line if no
-;;  region is defined, and kill-region is invoked.  It basically saves
-;;  you the effort of going to the begining of the line, selecting the
-;;  text up to the end of the line, and killing.  Similarly, when
-;;  yanking, it's smart enough to know that the string to be yanked
-;;  was killed as a whole line, and it should be yanked as one, too.
-;;  So you don't need to position yourself at the start of the line
-;;  before yanking.  If region *is* defined, though, all functions act
-;;  as normal.
+;; The primary use for this is to kill (cut) the current line if no
+;; region is defined, and kill-region is invoked.  It basically saves
+;; you the effort of going to the begining of the line, selecting the
+;; text up to the end of the line, and killing.  Similarly, when
+;; yanking, it's smart enough to know that the string to be yanked was
+;; killed as a whole line, and it should be yanked as one, too.  So
+;; you don't need to position yourself at the start of the line before
+;; yanking.  If region *is* defined, though, all functions act as
+;; normal.
 ;;
-;;  The inspiration for this came from an old editor I used to use
-;;  (brief maybe?), that did this exact thing for you.  It was a handy
-;;  feature to have, and I definitely wanted it when I moved to Emacs.
-;;  I've extended the concept slightly, to let you copy N whole lines,
-;;  using the standard prefix method.
+;; NOTE: This package will behave unexpectedly (and indeed is nearly
+;; useless) if `transient-mark-mode' is off, as there is then always a
+;; region defined.
 ;;
-;;  NOTE: This package will behave unexpectedly (and indeed is nearly
-;;  useless) if `transient-mark-mode' is off, as there is then always
-;;  a region defined.
-;;
-;;  NOTE: I haven't gotten this to work under XEmacs (though I
-;;  honestly haven't tried real hard).
-
 ;;; Usage:
 ;;
-;;  M-x `whole-line-or-region-local-mode'
+;; M-x `whole-line-or-region-local-mode'
 
-;;  Toggles whole-line-or-region-mode on & off on a per-buffer basis.
-;;  Optional arg turns whole-line-or-region-mode on iff arg is a
-;;  positive integer.  Then just call functions `copy-region-as-kill',
-;;  `kill-region', `kill-ring-save' and `yank' as you normally would.
+;; Use `whole-line-or-region-local-mode' to toggle the overridden
+;; behaviour on & off on a per-buffer basis.  This remaps common
+;; commands such as `copy-region-as-kill', `kill-ring-save' etc.
 ;;
-;;  To enable the mode for all buffers automatically whenever Emacs
-;;  starts, customize `whole-line-or-region-global-mode' (which see).
+;; To enable the mode for all buffers enable
+;; `whole-line-or-region-global-mode'.
 
 ;;; Extending Package:
 ;;
-;;  I've tried to make the base functions as generic as possible so
-;;  that this same concept can be used for other region-based
-;;  functions.  The only function I've thought of to date to extend in
-;;  this manner is `comment-dwim'.  Examples using `comment-dwim'
-;;  follow.
+;; In order to extend this package for additional region-based
+;; functions, you must understand how those functions work, and write
+;; a new stub function that will be used to replace it.  Several
+;; helper functions are defined in this package; which one to use
+;; depends on whether or not the original function wants region passed
+;; into it, or assumes region is defined before being called.
 ;;
-;;  In order to extend this package for additional region-based
-;;  functions, you must understand how those functions work, and write
-;;  a new stub function that will be used to replace it.  One of two
-;;  whole-line-or-region functions must be called from within that
-;;  stub; which one to use depends on whether or not the original
-;;  function wants region passed into it, or assumes region is defined
-;;  before being called.
-;;
-;;  Using `kill-region' as an example, looking at its definition we
-;;  see that it takes two arguments, BEG and END.  Looking at it
-;;  another way, it's interactive declaration is "r", which says to
-;;  pass in the current region.  Because of this, the stub function
-;;  for it should call `whole-line-or-region-call-with-region':
-;;
-;;     (defun whole-line-or-region-kill-region (prefix)
-;;       "Kill region or PREFIX whole lines."
-;;       (interactive "*p")
-;;       (whole-line-or-region-call-with-region 'kill-region prefix t))
-;;
-;;  The first argument to `whole-line-or-region-call-with-region' is
-;;  the function being replaced.  The second is the value for prefix,
-;;  so that the stub can operate on more than just one line (e.g. C-u
-;;  12 M-w would copy 12 whole lines).  Other arguments are explained
-;;  in the function documentation.
-;;
-;;  The function `comment-dwim', on the other hand, expects region to
-;;  be defined coming in, so its stub should call into the other
-;;  whole-line stub, `whole-line-or-region-call-with-prefix'.  There are
-;;  things to consider, though.  The original `comment-dwim' wants a
-;;  raw prefix value, but it doesn't use it to work over a variable
-;;  number of lines; rather it uses it to signal what DWIM really
-;;  does.  Sort of defeats the purpose of a DWIM command, if you ask
-;;  me -- it should be simple enough to determine from the current
-;;  context what DWIMs should do.  I digress, however.....
-;;
-;;  The "proper" way to write a whole-line version of `comment-dwim'
-;;  would be like the following:
-;;
-;;    (defun whole-line-or-region-comment-dwim (raw-prefix)
-;;      "Call `comment-dwim' on current region or current line."
-;;      (interactive "*P")
-;;      (whole-line-or-region-call-with-prefix 'comment-dwim 1 nil t raw-prefix))
-;;
-;;  The arguments for `whole-line-or-region-call-with-prefix' are
-;;  basically the same as for `whole-line-or-region-call-with-region',
-;;  but how each of them call the original function differs.  The
-;;  first one calls it with two arguments (i.e. region's BEG & END)
-;;  and the second one sets mark (i.e. defines region) and passes in
-;;  prefix (raw or processed, depending).
-;;
-;;  So the above example for `comment-dwim' would call the original
-;;  function with the current region (if defined) or the current line
-;;  (the second argument, the number of lines to operate on, being
-;;  hard-coded to 1), also passing in the raw prefix, for use within
-;;  the original function.  It retains its original semantics and just
-;;  saves you from having to mark the current line.
-;;
-;;  It could instead be defined like so:
-;;
-;;    (defun whole-line-or-region-comment-dwim-2 (prefix)
-;;      "Call `comment-dwim' on region or PREFIX whole lines."
-;;      (interactive "*p")
-;;      (whole-line-or-region-call-with-prefix 'comment-dwim prefix nil t))
-;;
-;;  What this version does is override the normal behavior of the
-;;  prefix arg to `comment-dwim', and instead uses it to indicate how
-;;  many lines the whole-line version will comment out -- no prefix
-;;  value is passed to the original function in this case.  This is
-;;  the version that I use, as it's just more intuitive for me.
-;;
-;;  After defining the new stub, however you do it, the package needs
-;;  to know about it so that it can toggle its use on and off as the
-;;  mode toggles on and off.  For that you need to customize the
-;;  variable `whole-line-or-region-extensions-alist', telling it the
-;;  original function name (`comment-dwim') and the new one
-;;  (`whole-line-or-region-comment-dwim-2').  If you want to limit the
-;;  redefinition to a specific keymap then specify that as well;
-;;  otherwise, the rebinding will occur in the global keymap.
-;;  Rebinding occurs via `substitute-key-definition' (which see).
+;; After defining the new stub, however you do it, the package needs
+;; to know about it so that it can toggle its use on and off as the
+;; mode toggles on and off.  For that you should modify
+;; `whole-line-or-region-local-mode-map' to remap the underlying
+;; command to your stub function, e.g.
 
-;;; To Do:
-;;
-;;  o Nothing, at the moment.
+;; (with-eval-after-load 'whole-line-or-region
+;;   (define-key whole-line-or-region-local-mode-map
+;;               [remap the-base-command]
+;;               'my-stub-command))
 
 ;;; Code:
 
-(require 'delsel)
+(require 'cl-lib)
 
-;;; Keymap
-(defvar whole-line-or-region-local-mode-map (make-sparse-keymap)
-  "Minor mode map for `whole-line-or-region-mode'.")
-
-;;; **************************************************************************
-;;; ***** customization
-;;; **************************************************************************
 (defgroup whole-line-or-region nil
   "Customization group for whole-line-or-region minor mode."
   :group 'editing-basics
   :group 'convenience)
 
-;; ---------------------------------------------------------------------------
-(defun whole-line-or-region-customize ()
-  "Customization of the group 'whole-line-or-region'."
-  (interactive)
-  (customize-group "whole-line-or-region"))
-
-;; ---------------------------------------------------------------------------
-
-;;;###autoload
-(defun whole-line-or-region-bind-keys ()
-  "Bind keys according to `whole-line-or-region-extensions-alist'."
-  (dolist (elem whole-line-or-region-extensions-alist)
-    (substitute-key-definition
-     (nth 0 elem)
-     (nth 1 elem)
-     whole-line-or-region-local-mode-map
-     (or (nth 2 elem) (current-global-map)))))
-
-(defcustom whole-line-or-region-extensions-alist
-  '((copy-region-as-kill whole-line-or-region-copy-region-as-kill nil)
-    (kill-region whole-line-or-region-kill-region nil)
-    (kill-ring-save whole-line-or-region-kill-ring-save nil)
-    (yank whole-line-or-region-yank nil))
-  "List of functions for whole-line-or-region to swap.
-
-When whole-line-or-region is activated, all original functions
-will be bound to their whole-line counterparts in
-`whole-line-or-region-local-mode-map', with the bindings taken from
-global keymap, or the optionally specified keymap.
-
-The default is to map the following:
-
-  o `copy-region-as-kill'  ->  `whole-line-or-region-copy-region-as-kill'
-  o `kill-region'          ->  `whole-line-or-region-kill-region'
-  o `kill-ring-save'       ->  `whole-line-or-region-kill-ring-save'
-  o `yank'                 ->  `whole-line-or-region-yank'
-
-In addition, the following functions are provided by the package for
-your convenience:
-
-  o `whole-line-or-region-delete'
-  o `whole-line-or-region-comment-dwim'
-  o `whole-line-or-region-comment-dwim-2'
-  o `whole-line-or-region-comment-region'
-  o `whole-line-or-region-uncomment-region'
-
-See the individual functions for more information on what they do and
-suggested mappings.
-
-If you set this through other means than customize be sure to run
-`whole-line-or-region-bind-keys' afterwards"
-  :type '(repeat
-          (list :tag "Function Mappings:"
-                (function :tag "Original Function")
-                (function :tag "Whole-line Version")
-                (variable :tag "Keymap (optional)")))
-  :group 'whole-line-or-region
-  :set (lambda (symbol newval)
-         (set-default symbol newval)
-         (whole-line-or-region-bind-keys)))
-
-;;; **************************************************************************
-;;; ***** minor mode definitions
-;;; **************************************************************************
+;;; Keymap
+(defvar whole-line-or-region-local-mode-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map [remap kill-region] 'whole-line-or-region-kill-region)
+    (define-key map [remap kill-ring-save] 'whole-line-or-region-kill-ring-save)
+    (define-key map [remap copy-region-as-kill] 'whole-line-or-region-copy-region-as-kill)
+    (define-key map [remap delete-region] 'whole-line-or-region-delete-region)
+    (define-key map [remap comment-dwim] 'whole-line-or-region-comment-dwim-2)
+    (define-key map [remap comment-region] 'whole-line-or-region-comment-region)
+    (define-key map [remap uncomment-region] 'whole-line-or-region-uncomment-region)
+    map)
+  "Minor mode map for `whole-line-or-region-mode'.")
 
 ;;;###autoload
 (define-minor-mode whole-line-or-region-local-mode
-  "Toggle use of whole-line-or-region minor mode.
-
-This minor mode allows functions to operate on the current line if
-they would normally operate on a region and region is currently
-undefined.
-
-Optional ARG turns mode on iff ARG is a positive integer."
-  :group 'whole-line-or-region
+  "Make chosen commands operate on the current line if no region is active.
+Modify `whole-line-or-region-local-mode-map' to change which
+commands are affected."
   :lighter " WLR"
   :keymap 'whole-line-or-region-local-mode-map)
 
 ;;;###autoload
 (define-globalized-minor-mode whole-line-or-region-global-mode
   whole-line-or-region-local-mode
-  whole-line-or-region--turn-on
-  :group 'whole-line-or-region)
+  (lambda () (whole-line-or-region-local-mode 1)))
 
-(defun whole-line-or-region--turn-on ()
-  (whole-line-or-region-local-mode +1))
 
-;;; **************************************************************************
-;;; ***** interactive functions (used by default)
-;;; **************************************************************************
+
+;;; Yank handler
+
+(defun whole-line-or-region-yank-handler (string)
+  "Yank handler which operates at the beginning of the line.
+STRING is the string being yanked."
+  (if (and (not (and delete-selection-mode mark-active))
+           whole-line-or-region-local-mode)
+      (save-excursion
+        (move-beginning-of-line 1)
+        (insert string)
+        (unless (eq (char-before) ?\n)
+          (insert "\n")))
+    (insert string)))
+
+
+;;; Helpers for wrapping commands
+
+(defmacro whole-line-or-region-filter-with-yank-handler (&rest body)
+  "Execute BODY with `filter-buffer-substring-function' bound.
+The binding ensure killed strings have a yank handler attached."
+  (let ((orig (cl-gensym)))
+    `(let* ((,orig filter-buffer-substring-function)
+            (filter-buffer-substring-function
+             (lambda (&rest args)
+               (let ((s (apply ,orig args)))
+                 (propertize s 'yank-handler
+                             (list 'whole-line-or-region-yank-handler s t))))))
+       ,@body)))
+
+(defun whole-line-or-region-wrap-region-kill (f num-lines)
+  "Wrap a region function F, such as `kill-region'.
+
+Such functions are expected to accept the arguments (BEG END &optional REGION).
+
+If NUM-LINES is non-zero and the region is inactive, it denotes
+the number of lines to operate upon, where positive numbers
+indicate lines after point, and negative numbers represent lines
+preceding point."
+  (if (use-region-p)
+      (funcall f (region-beginning) (region-end) 'region)
+    (whole-line-or-region-filter-with-yank-handler
+     (funcall f
+              (line-beginning-position 1)
+              (line-beginning-position (+ 1 num-lines))
+              nil))))
+
+(defun whole-line-or-region-wrap-beg-end (f num-lines &rest rest)
+  "Wrap function F and call it passing the possibly-expanded region.
+F is assumed to take the parameters (BEG END &rest REST),
+which will all be passed through unchanged, except that BEG and END may
+be adjusted.
+
+If NUM-LINES is non-zero and the region is inactive, it denotes
+the number of lines to operate upon, where positive numbers
+indicate lines after point, and negative numbers represent lines
+preceding point."
+  (if (use-region-p)
+      (apply f (region-beginning) (region-end) rest)
+    (apply f
+           (line-beginning-position 1)
+           (line-beginning-position (+ 1 num-lines))
+           rest)))
+
+(defun whole-line-or-region-wrap-modified-region (f num-lines &rest rest)
+  "Wrap function F and call it passing the possibly-expanded region.
+F is assumed to take the parameters (&rest REST), which will all
+be passed through unchanged.
+
+The current region will be temporarily expanded if necessary
+while F is called.
+
+If NUM-LINES is non-zero and the region is inactive, it denotes
+the number of lines to operate upon, where positive numbers
+indicate lines after point, and negative numbers represent lines
+preceding point."
+  (if (use-region-p)
+      (apply f rest)
+    (save-excursion
+      (set-mark (line-beginning-position 1))
+      (goto-char (line-beginning-position (+ 1 num-lines)))
+      (apply f rest))))
+
+
+;;; Wrappers for commonly-used functions
+
 ;;;###autoload
 (defun whole-line-or-region-copy-region-as-kill (prefix)
-  "Copy region or PREFIX whole lines."
-  (interactive "p")
-  (whole-line-or-region-call-with-region 'copy-region-as-kill prefix t))
+  "Call `copy-region-as-kill' on region or PREFIX whole lines."
+  (interactive "*p")
+  (whole-line-or-region-wrap-region-kill 'copy-region-as-kill prefix))
 
 ;;;###autoload
 (defun whole-line-or-region-kill-region (prefix)
-  "Kill (cut) region or PREFIX whole lines."
+  "Call `kill-region' on region or PREFIX whole lines."
   (interactive "*p")
-  (whole-line-or-region-call-with-region 'kill-region prefix t))
+  (whole-line-or-region-wrap-region-kill 'kill-region prefix))
 
 ;;;###autoload
 (defun whole-line-or-region-kill-ring-save (prefix)
-  "Copy region or PREFIX whole lines."
-  (interactive "p")
-  (whole-line-or-region-call-with-region 'kill-ring-save prefix t))
-
-;;;###autoload
-(defun whole-line-or-region-yank (raw-prefix &optional string-in)
-  "Yank (paste) previously killed text.
-
-If the text to be yanked was killed with a whole-line-or-region
-function *as* a whole-line, then paste it as a whole line (i.e. do not
-break up the current line, and do not force the user to move point).
-
-RAW-PREFIX is used to determine which string to yank, just as `yank'
-would normally use it.
-
-Optionally, pass in string to be \"yanked\" via STRING-IN."
-  (interactive "*P")
-
-  ;; figure out what yank would do normally
-  (let ((string-to-yank (or string-in (current-kill
-                                       (cond ((listp raw-prefix) 0)
-                                             ((eq raw-prefix '-) -1)
-                                             (t (1- raw-prefix))) t)))
-        (saved-column (current-column)))
-
-    ;; check for whole-line prop in yanked text
-    (if (get-text-property 0 'whole-line-or-region string-to-yank)
-        (let ((beg (line-beginning-position)))
-          ;; goto beg of line and yank
-          (beginning-of-line)
-          (if string-in
-              ;; insert "manually"
-              (insert string-in)
-            ;; just yank as normal
-            (yank raw-prefix))
-
-          ;; a whole-line killed from end of file may not have a
-          ;; trailing newline -- add one, in these cases
-          (when (not (string-match "\n$" string-to-yank))
-            (insert "\n")
-            (forward-line -1))
-
-          ;; restore state of being....
-          (move-to-column saved-column)
-          (remove-text-properties beg (+ beg 1) '(whole-line-or-region nil)))
-
-      ;; no whole-line-or-region mark
-      (if string-in
-          ;; insert "manually"
-          (progn
-            (when (and delete-selection-mode
-                       mark-active)
-              (delete-active-region))
-            (insert string-in))
-        ;; just yank as normal
-        (yank raw-prefix)))))
-
-;; in case delete-selection-mode (delsel.el) is being used
-(put 'whole-line-or-region-yank 'delete-selection t)
-
-;;; **************************************************************************
-;;; alternate interactive functions
-;;; **************************************************************************
-;;;###autoload
-(defun whole-line-or-region-delete (prefix)
-  "Delete region or PREFIX whole lines."
+  "Call `kill-ring-save' on region or PREFIX whole lines."
   (interactive "*p")
-  (whole-line-or-region-call-with-region 'delete-region prefix))
+  (whole-line-or-region-wrap-region-kill 'kill-ring-save prefix))
 
 ;;;###autoload
-(defun whole-line-or-region-comment-dwim (raw-prefix)
-  "Call `comment-dwim' on current region or current line.
-
-See `comment-dwim' for details of RAW-PREFIX usage."
-  (interactive "*P")
-  (whole-line-or-region-call-with-prefix 'comment-dwim 1 nil t raw-prefix))
-
-;;;###autoload
-(defun whole-line-or-region-comment-dwim-2 (prefix)
-  "Call `comment-dwim' on region or PREFIX whole lines."
+(defun whole-line-or-region-delete-region (prefix)
+  "Call `delete-region' on region or PREFIX whole lines."
   (interactive "*p")
-  (whole-line-or-region-call-with-prefix 'comment-dwim prefix nil t))
+  (whole-line-or-region-wrap-beg-end 'delete-region prefix))
 
 ;;;###autoload
 (defun whole-line-or-region-comment-region (prefix)
   "Call `comment-region' on region or PREFIX whole lines."
   (interactive "*p")
-  (whole-line-or-region-call-with-region 'comment-region prefix t))
+  (whole-line-or-region-wrap-beg-end 'comment-region prefix))
+
+;;;###autoload
+(defun whole-line-or-region-comment-dwim (prefix)
+  "Call `comment-dwim' on region or current line.
+PREFIX is passed unchanged to `comment-dwim'."
+  (interactive "*P")
+  (whole-line-or-region-wrap-modified-region 'comment-dwim 1 prefix))
+
+;;;###autoload
+(defun whole-line-or-region-comment-dwim-2 (prefix)
+  "Call `comment-dwim' on region or PREFIX whole line."
+  (interactive "*p")
+  (whole-line-or-region-wrap-modified-region 'comment-dwim prefix nil))
 
 ;;;###autoload
 (defun whole-line-or-region-uncomment-region (prefix)
   "Call `uncomment-region' on region or PREFIX whole lines."
   (interactive "*p")
-  (whole-line-or-region-call-with-region 'uncomment-region prefix t))
+  (whole-line-or-region-wrap-beg-end 'uncomment-region prefix t))
 
+;;;###autoload
+(defun whole-line-or-region-comment-or-uncomment-region (prefix)
+  "Call `comment-or-uncomment-region' on region or PREFIX whole lines."
+  (interactive "P")
+  (whole-line-or-region-wrap-beg-end 'comment-or-uncomment-region prefix t))
 
-;;; **************************************************************************
-;;; ***** internal functions
-;;; **************************************************************************
-(defun whole-line-or-region-call-with-region (fn &optional cnt mark-as-whole send-prefix prefix)
-  "Calls FN on region or CNT whole lines.
-
-If region is defined simply call FN, passing in the start and end of
-the current region.
-
-If region is not currently defined, then define it temporarily as the
-current line.  Additionally, if CNT is set, expand region to cover the
-next CNT whole lines (or previous CNT whole lines, if CNT is
-negative).  Before FN is called, mark the temporary region with a
-special property if MARK-AS-WHOLE is non-nil (this is useful if the
-text could be worked on with some future whole-line-or-region
-function, and it makes sense to understand the context in which FN was
-originally called, e.g. killing and yanking text; see
-`whole-line-or-region-yank' for an example).
-
-In either case, if SEND-PREFIX is non-nil, then PREFIX is passed into
-FN as a third argument."
-  (whole-line-or-region-base-call fn fn t nil nil cnt mark-as-whole send-prefix prefix))
-
-(defun whole-line-or-region-call-with-prefix (fn &optional cnt mark-as-whole send-prefix prefix)
-  "Calls FN on region or CNT whole lines.
-
-If region is defined simply call FN.
-
-If region is not currently defined, then define it temporarily as the
-current line.  Additionally, if CNT is set, expand region to cover the
-next CNT whole lines (or previous CNT whole lines, if CNT is
-negative).  Before FN is called, mark the temporary region with a
-special property if MARK-AS-WHOLE is non-nil (this is useful if the
-text could be worked on with some future whole-line-or-region
-function, and it makes sense to understand the context in which FN was
-originally called, e.g. killing and yanking text; see
-`whole-line-or-region-yank' for an example).
-
-In either case, if SEND-PREFIX is non-nil, then PREFIX is passed into
-FN as the sole argument."
-  (whole-line-or-region-base-call fn fn nil nil nil cnt mark-as-whole send-prefix prefix))
-
-(defun whole-line-or-region-base-call (norm-fn wlr-fn
-                                               &optional beg-end pre-args post-args
-                                               cnt mark-as-whole send-prefix prefix)
-  "Calls FN on region or CNT whole lines.
-
-If region is defined simply call NORM-FN.
-
-If region is not currently defined, then define it temporarily as the
-current line.  Additionally, if CNT is set, expand region to cover the
-next CNT whole lines (or previous CNT whole lines, if CNT is
-negative).  Before WLR-FN is called, mark the temporary region with a
-special property if MARK-AS-WHOLE is non-nil (this is useful if the
-text could be worked on with some future whole-line-or-region
-function, and it makes sense to understand the context in which WLR-FN was
-originally called, e.g. killing and yanking text; see
-`whole-line-or-region-yank' for an example).
-
-In either case, if BEG-END is non-nil, then pass into FN the start and
-end of the current region.  PRE-ARGS and POST-ARGS are lists of
-arguments to be passed into FN before \(PRE-ARGS) and/or after
-\(POST-ARGS) the start and end of the current region (but only if
-BEG-END is non-nil).  Finally, if SEND-PREFIX is non-nil, then PREFIX
-is passed into FN before POST-ARGS."
-
-  ;; region is defined, so just do what should normally be done
-  (if (and mark-active
-           (/= (point) (mark)))
-      ;; just call it, but make sure to pass all of the arguments....
-      (let ((args (append (when pre-args pre-args)
-                          (when beg-end (list (point) (mark)))
-                          (when send-prefix (list prefix))
-                          (when post-args post-args))))
-        (apply norm-fn args))
-
-    ;; no region defined, act on whole line
-    (let ((saved-column (current-column))
-          (current-mod-state (buffer-modified-p))
-          beg end)
-      (save-excursion
-        (setq beg (line-beginning-position))
-        (set-mark beg)
-
-        ;; add whole-line property, sometimes
-        (when mark-as-whole
-          (let ((inhibit-read-only t))
-            (put-text-property beg (min (point-max) (+ beg 1)) 'whole-line-or-region t)
-            (set-buffer-modified-p current-mod-state)))
-
-        (setq end (line-beginning-position (+ (or cnt 1) 1)))
-        (goto-char end)
-
-        (let ((args (append (when pre-args pre-args)
-                            (when beg-end (list beg end))
-                            (when send-prefix (list prefix))
-                            (when post-args post-args))))
-          (apply wlr-fn args))
-
-        ;; remove whole-line property, sometimes
-        (when mark-as-whole
-          (let ((inhibit-read-only t)
-                (current-mod-state (buffer-modified-p)))
-            (remove-text-properties beg (min (point-max) (+ beg 1)) '(whole-line-or-region nil))
-            (set-buffer-modified-p current-mod-state))))
-
-      (move-to-column saved-column))))
-
-
-;; FIXME, is just running it here once the reasonable thing to do?
-(whole-line-or-region-bind-keys)
 
 (provide 'whole-line-or-region)
 

--- a/whole-line-or-region.el
+++ b/whole-line-or-region.el
@@ -136,7 +136,7 @@ When ENSURE-NEWLINE is non-nil, add a newline if there was none."
   (let ((beg (point))
         end)
     (insert string)
-    (remove-yank-excluded-properties (point) (- (point) (length string)))
+    (remove-yank-excluded-properties beg (point))
     (when (and ensure-newline (not (eq (char-before) ?\n)))
       (insert "\n"))
     (setq end (point))

--- a/whole-line-or-region.el
+++ b/whole-line-or-region.el
@@ -161,7 +161,7 @@ The binding ensure killed strings have a yank handler attached."
              (lambda (&rest args)
                (let ((s (apply ,orig args)))
                  (propertize s 'yank-handler
-                             (list 'whole-line-or-region-yank-handler s t))))))
+                             (list 'whole-line-or-region-yank-handler nil t))))))
        ,@body)))
 
 (defun whole-line-or-region-wrap-region-kill (f num-lines)

--- a/whole-line-or-region.el
+++ b/whole-line-or-region.el
@@ -121,9 +121,11 @@ commands are affected."
 STRING is the string being yanked."
   (if (and (not (and delete-selection-mode mark-active))
            whole-line-or-region-local-mode)
-      (save-excursion
+      (let ((initial-pos (point-marker)))
         (forward-line 0)
-        (whole-line-or-region-insert-clean string t))
+        (prog1
+            (whole-line-or-region-insert-clean string t)
+          (goto-char initial-pos)))
     (whole-line-or-region-insert-clean string nil)))
 
 (defun whole-line-or-region-insert-clean (string &optional ensure-newline)
@@ -136,6 +138,7 @@ When ENSURE-NEWLINE is non-nil, add a newline if there was none."
   (let ((beg (point))
         end)
     (insert-before-markers string)
+    (push-mark beg)
     (remove-yank-excluded-properties beg (point))
     (when (and ensure-newline (not (eq (char-before) ?\n)))
       (insert-before-markers "\n"))

--- a/whole-line-or-region.el
+++ b/whole-line-or-region.el
@@ -2,8 +2,9 @@
 
 ;; This file is not part of Emacs
 
-;; Copyright (C) 2001 by Joseph L. Casadonte Jr.
 ;; Copyright (C) 2011-2020 Steve Purcell
+;; Copyright (C) 2001 by Joseph L. Casadonte Jr.
+
 ;; Author:          Joe Casadonte <emacs@northbound-train.com>
 ;; Author:          Steve Purcell <steve@sanityinc.com>
 ;; Maintainer:      Steve Purcell <steve@sanityinc.com>
@@ -27,7 +28,7 @@
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 ;;; Commentary:
-;;
+
 ;; This minor mode allows functions to operate on the current line if
 ;; they would normally operate on a region and region is currently
 ;; undefined.
@@ -41,24 +42,18 @@
 ;; you don't need to position yourself at the start of the line before
 ;; yanking.  If region *is* defined, though, all functions act as
 ;; normal.
-;;
-;; NOTE: This package will behave unexpectedly (and indeed is nearly
-;; useless) if `transient-mark-mode' is off, as there is then always a
-;; region defined.
-;;
+
 ;;; Usage:
-;;
+
 ;; M-x `whole-line-or-region-local-mode'
 
 ;; Use `whole-line-or-region-local-mode' to toggle the overridden
 ;; behaviour on & off on a per-buffer basis.  This remaps common
 ;; commands such as `copy-region-as-kill', `kill-ring-save' etc.
 ;;
-;; To enable the mode for all buffers enable
+;; To enable the mode for all buffers, enable
 ;; `whole-line-or-region-global-mode'.
 
-;;; Extending Package:
-;;
 ;; In order to extend this package for additional region-based
 ;; functions, you must understand how those functions work, and write
 ;; a new stub function that will be used to replace it.  Several
@@ -132,7 +127,7 @@ STRING is the string being yanked."
   "Insert STRING and remove `yank-excluded-properties'.
 This is needed because the yank handler may move point, and is
 therefore registered with the NOEXCLUDE flag: this causes `yank'
-to not remove the excluded properties itself
+to not remove the excluded properties itself.
 
 When ENSURE-NEWLINE is non-nil, add a newline if there was none."
   (let ((beg (point))


### PR DESCRIPTION
- Allows `rectangle-mark-mode` to work as expected (fixes #9)
- Uses `yank-handler`, so no need to replace the `yank` command
- Improved preservation of point, generally to improve correctness. However, after yanking full lines, the point is now preserved, not placed at the line beginning, so feedback would be appreciated regarding how this feels.
- Default override for `comment-dwim` is changed, and now uses prefix to denote the number of lines to comment/uncomment, rather than comment level
- Removed the obsolete `whole-line-or-region-mode` alias: use either the `-local-mode` or the `-global-mode` now.
- Removed the old-fashioned "turn-on" function
- Greatly improved tests

Plan would be to release this as v2.0