### PR TITLE
added wrappers for rigid indentation commands

### DIFF
--- a/whole-line-or-region-test.el
+++ b/whole-line-or-region-test.el
@@ -433,6 +433,41 @@ third"
 sesecond
 th|third"))
 
+(ert-deftest wlr-indent-rigidly-right-with-region ()
+  (wlr-before-after
+   "first
+sec|ond
+third"
+   (set-mark (point-min))
+   (call-interactively 'whole-line-or-region-indent-rigidly-right)
+   " first
+ sec|ond
+third"))
+
+(ert-deftest wlr-indent-rigidly-right ()
+  (wlr-before-after
+   "fir|st
+second
+third"
+   (call-interactively 'whole-line-or-region-indent-rigidly-right)
+   " fir|st
+second
+third"))
+
+(ert-deftest wlr-indent-rigidly-right-left-to-tabstop ()
+  (let ((tab-stop-list '(0 3 6)))
+    (wlr-before-after
+     "fir|st
+second
+third"
+     (call-interactively 'whole-line-or-region-indent-rigidly-right-to-tab-stop)
+     (call-interactively 'whole-line-or-region-indent-rigidly-right-to-tab-stop)
+     (call-interactively 'whole-line-or-region-indent-rigidly-left-to-tab-stop)
+     "   fir|st
+second
+third")))
+
+
 
 (provide 'whole-line-or-region-test)
 

--- a/whole-line-or-region.el
+++ b/whole-line-or-region.el
@@ -91,6 +91,10 @@
     (define-key map [remap comment-dwim] 'whole-line-or-region-comment-dwim-2)
     (define-key map [remap comment-region] 'whole-line-or-region-comment-region)
     (define-key map [remap uncomment-region] 'whole-line-or-region-uncomment-region)
+    (define-key map [remap indent-rigidly-left-to-tab-stop] 'whole-line-or-region-indent-rigidly-left-to-tab-stop)
+    (define-key map [remap indent-rigidly-right-to-tab-stop] 'whole-line-or-region-indent-rigidly-right-to-tab-stop)
+    (define-key map [remap indent-rigidly-left] 'whole-line-or-region-indent-rigidly-left)
+    (define-key map [remap indent-rigidly-right] 'whole-line-or-region-indent-rigidly-right)
     map)
   "Minor mode map for `whole-line-or-region-mode'.")
 
@@ -286,6 +290,29 @@ PREFIX is passed unchanged to `comment-dwim'."
   (interactive "P")
   (whole-line-or-region-wrap-beg-end 'comment-or-uncomment-region prefix t))
 
+;;;###autoload
+(defun whole-line-or-region-indent-rigidly-left-to-tab-stop (prefix)
+  "Call `indent-rigidly-left-to-tab-stop' on region or PREFIX whole lines."
+  (interactive "*p")
+  (whole-line-or-region-wrap-beg-end 'indent-rigidly-left-to-tab-stop prefix))
+
+;;;###autoload
+(defun whole-line-or-region-indent-rigidly-right-to-tab-stop (prefix)
+  "Call `indent-rigidly-right-to-tab-stop' on region or PREFIX whole lines."
+  (interactive "*p")
+  (whole-line-or-region-wrap-beg-end 'indent-rigidly-right-to-tab-stop prefix))
+
+;;;###autoload
+(defun whole-line-or-region-indent-rigidly-left (prefix)
+  "Call `indent-rigidly-left-to-tab-stop' on region or PREFIX whole lines."
+  (interactive "*p")
+  (whole-line-or-region-wrap-beg-end 'indent-rigidly-left prefix))
+
+;;;###autoload
+(defun whole-line-or-region-indent-rigidly-right (prefix)
+  "Call `indent-rigidly-right-to-tab-stop' on region or PREFIX whole lines."
+  (interactive "*p")
+  (whole-line-or-region-wrap-beg-end 'indent-rigidly-right prefix))
 
 (provide 'whole-line-or-region)
 


### PR DESCRIPTION
`indent-rigidly-...` commands come in handy with python often. 
I think this is a good candidate to be added here, since the default behaviour is similar to what `kill-region` does.

I really enjoy the package, and love the tests that you set up!

Thanks.