### PR TITLE
Fix #26

### DIFF
--- a/whole-line-or-region-test.el
+++ b/whole-line-or-region-test.el
@@ -343,6 +343,7 @@ third|"))
    "fir|st
 second
 third"
+   (transient-mark-mode 1)
    (set-mark (point-min))
    (call-interactively 'whole-line-or-region-comment-dwim)
    "# fir|
@@ -374,6 +375,7 @@ third"))
 (ert-deftest wlr-yank-region-delete-selection ()
   (wlr-before-after
    "fir|st"
+   (transient-mark-mode 1)
    (delete-selection-mode)
    (set-mark (point-min))
    (goto-char (point-max))
@@ -392,6 +394,7 @@ third"))
   (wlr-before-after
    "fir|st
 second"
+   (transient-mark-mode 1)
    (delete-selection-mode)
    (call-interactively 'whole-line-or-region-kill-region)
    "sec|ond"

--- a/whole-line-or-region-test.el
+++ b/whole-line-or-region-test.el
@@ -509,6 +509,29 @@ third"
 second
 third")))
 
+(ert-deftest wlr-regression-issue-26 ()
+  (wlr-before-after
+   "CREATE TABLE account (
+  name VARCHAR(10) NOT NULL
+);|"
+   (buffer-enable-undo)
+   (transient-mark-mode 1)
+   (goto-line 2)
+   (call-interactively 'whole-line-or-region-kill-region)
+   "CREATE TABLE account (
+|);"
+   (primitive-undo 1 buffer-undo-list)
+   "CREATE TABLE account (
+|  name VARCHAR(10) NOT NULL
+);"
+   (search-forward "10")
+   (set-mark (- (point) 2))
+   (should (region-active-p))
+   (call-interactively 'whole-line-or-region-kill-ring-save)
+   (call-interactively 'yank)
+   "CREATE TABLE account (
+  name VARCHAR(1010|) NOT NULL
+);"))
 
 
 (provide 'whole-line-or-region-test)

--- a/whole-line-or-region.el
+++ b/whole-line-or-region.el
@@ -230,9 +230,12 @@ preceding point."
   (if (whole-line-or-region-use-region-p)
       (apply f rest)
     (save-excursion
-      (set-mark (line-beginning-position 1))
-      (goto-char (line-beginning-position (+ 1 num-lines)))
-      (apply f rest))))
+      (let
+          ;; The subsequent function call might require Transient Mark Mode awareness
+          ((transient-mark-mode 'lambda))
+        (set-mark (line-beginning-position 1))
+        (goto-char (line-beginning-position (+ 1 num-lines)))
+        (apply f rest)))))
 
 
 ;;; Wrappers for commonly-used functions

--- a/whole-line-or-region.el
+++ b/whole-line-or-region.el
@@ -173,11 +173,9 @@ The binding ensure killed strings have a yank handler attached."
     `(let* ((,orig filter-buffer-substring-function)
             (filter-buffer-substring-function
              (lambda (&rest args)
-               (let ((s (apply ,orig args)))
-                 (put-text-property 0 (length s) 'yank-handler
-                                    '(whole-line-or-region-yank-handler nil t)
-                                    s)
-                 s))))
+               (propertize (apply ,orig args)
+                           'yank-handler
+                           '(whole-line-or-region-yank-handler nil t)))))
        ,@body)))
 
 (defun whole-line-or-region-wrap-region-kill (f num-lines)


### PR DESCRIPTION
Fix #26.

The main change is to use `propertize` instead of `put-text-property` on `filter-buffer-substring-function` to avoid modifying `buffer-undo-list`. I'm not quite sure this change is safe and doesn't break anything.
